### PR TITLE
Fix two issues reading a project

### DIFF
--- a/doxyphp2sphinx/rstgenerator.py
+++ b/doxyphp2sphinx/rstgenerator.py
@@ -99,7 +99,7 @@ class RstGenerator:
             # called on the class which defines them.
             return ret
         for base_class in compounddef.iter('basecompoundref'):
-            if not 'refid' in base_class:
+            if not 'refid' in base_class.attrib:
                 # Extends a class that is not documented here, eg. sub-class of RuntimeException
                 continue
             # Add inherited methods
@@ -125,7 +125,7 @@ class RstGenerator:
         extends = []
         implements = []
         for base_class in compounddef.iter('basecompoundref'):
-            if not 'refid' in base_class:
+            if not 'refid' in base_class.attrib:
                 # Base class not part of this project
                 continue
             baserefid = base_class.attrib['refid']

--- a/doxyphp2sphinx/rstgenerator.py
+++ b/doxyphp2sphinx/rstgenerator.py
@@ -99,6 +99,10 @@ class RstGenerator:
             # called on the class which defines them.
             return ret
         for base_class in compounddef.iter('basecompoundref'):
+            if not 'refid' in base_class:
+                # Extends a class that is not documented here, eg. sub-class of RuntimeException
+                continue
+            # Add inherited methods
             refid = base_class.attrib['refid']
             base_compound_def = self.compounddef_by_ref_id(refid)
             inherited = self.class_member_dict(base_compound_def, member_kind)
@@ -121,6 +125,9 @@ class RstGenerator:
         extends = []
         implements = []
         for base_class in compounddef.iter('basecompoundref'):
+            if not 'refid' in base_class:
+                # Base class not part of this project
+                continue
             baserefid = base_class.attrib['refid']
             base_compound_def = self.compounddef_by_ref_id(baserefid)
             if base_compound_def.attrib['kind'] == "class":
@@ -175,8 +182,9 @@ class RstGenerator:
             # Use documented param list if present
             for arg in params.iter('parameteritem'):
                 argname = arg.find('parameternamelist')
-                argname_type = argname.find('parametertype').text
                 argname_name = argname.find('parametername').text
+                paramtype = argname.find('parametertype')
+                argname_type = paramtype.text if paramtype is not None else ''
                 argdesc = arg.find('parameterdescription')
                 argdesc_para = argdesc.iter('para')
                 doco = ("    :param " + argname_type).rstrip() + " " + argname_name + ":\n"


### PR DESCRIPTION
Attempted to render docs for https://github.com/brotkrueml/jobrouter-client

- `@throws` declarations threw off the XML-to-RST converter, because they appear as method parameters, but contain different information.
- A crash when a class `extends RuntimeException`, because built-in classes have no `refid` in doxygen. The superclass is ignored here, but we could probably improve this so that at least the name is included.